### PR TITLE
 Revert FFmpeg version to 5.0

### DIFF
--- a/io.github.helpseeker.Gyre.json
+++ b/io.github.helpseeker.Gyre.json
@@ -36,7 +36,7 @@
                 "--enable-protocol=file",
                 "--enable-decoder=h264,mp3",
                 "--enable-encoder=wrapped_avframe,pcm_s16le",
-                "--enable-demuxer=concat,mov,mp3,asf",
+                "--enable-demuxer=concat,mov,mp3",
                 "--enable-muxer=matroska,mp4,asf,avi,flv,f4v,mov,null",
                 "--enable-bsf=h264_mp4toannexb",
                 "--enable-filter=aresample"
@@ -45,7 +45,7 @@
                 {
                     "type" : "git",
                     "url" : "https://git.ffmpeg.org/ffmpeg.git",
-                    "tag" : "n6.0"
+                    "tag" : "n5.0"
                 }
             ]
         },
@@ -77,8 +77,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/HelpSeeker/Gyre.git",
-                    "tag" : "v0.1.4",
-                    "commit" : "6ee9d00bf34105bbbae9018ffb377a8b427d90dc"
+                    "tag" : "v0.1.4.1",
+                    "commit" : "3627a5fecbedd716becf20b6064f99aad2ebdc1d"
                 }
             ]
         }


### PR DESCRIPTION
The update to v6.0 breaks proper concatenation in several cases. I'm not sure what has changed exactly, but I have to figure out a new minimal build configuration that works from scratch.

Until then let's just stick with the tried and tested v5.0.